### PR TITLE
Fix the integration test due to PR 374

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -209,7 +209,8 @@ class TestContainer(IntegrationTestCase):
         )
 
         self.assertEqual(0, result.exit_code)
-        self.assertEqual(test_msg, result.stdout)
+        # if a handler is supplied then there is no stdout in result
+        self.assertEqual('', result.stdout)
         self.assertEqual('', result.stderr)
         self.assertEqual(stdout_msgs, [test_msg])
 


### PR DESCRIPTION
PR#374 introduced a change in behaviour where the stdout/stderr is not
stored if a handler is supplied.  This shouldn't affect most people as,
if you are using a handler, then the code is already doing something
with stdout/stderr.

Signed-off-by: Alex Kavanagh <alex.kavanagh@canonical.com>