### PR TITLE
Update code for fixed issues in LXD 

### DIFF
--- a/doc/source/instances.rst
+++ b/doc/source/instances.rst
@@ -211,10 +211,7 @@ us to use our own namespacing).
 A instance object (returned by `get` or `all`) has the following methods:
 
   - `rename` - rename a snapshot
-  - `publish` - create an image from a snapshot.  However, this may fail if the
-    image from the snapshot is bigger than the logical volume that is allocated
-    by lxc.  See https://github.com/canonical/lxd/issues/2201 for more details.  The solution
-    is to increase the `storage.lvm_volume_size` parameter in lxc.
+  - `publish` - create an image from a snapshot.
   - `restore` - restore the instance to this snapshot.
 
 .. code-block:: python

--- a/integration/test_storage.py
+++ b/integration/test_storage.py
@@ -83,6 +83,7 @@ class TestStoragePools(StorageTestCase):
 
         storage_pool = self.client.storage_pools.get(name)
         new_desc = "new description"
+        self.assertNotEqual(storage_pool.description, new_desc)
         put_object = {
             "description": new_desc,
             "config": storage_pool.config,
@@ -98,6 +99,7 @@ class TestStoragePools(StorageTestCase):
 
         storage_pool = self.client.storage_pools.get(name)
         new_desc = "new description"
+        self.assertNotEqual(storage_pool.description, new_desc)
         patch_object = {
             "description": new_desc,
         }

--- a/integration/test_storage.py
+++ b/integration/test_storage.py
@@ -92,22 +92,19 @@ class TestStoragePools(StorageTestCase):
         p = self.client.storage_pools.get(name)
         self.assertEqual(p.description, new_desc)
 
-    # can't test this as patch doesn't seem to work for storage pools.
-    # Need to wait until bug: https://github.com/canonical/lxd/issues/4709
-    # fix is released.
-    @unittest.skip("Can't test until fix to lxd bug #4709 is released")
     def test_patch(self):
         name = self.create_storage_pool()
         self.addCleanup(self.delete_storage_pool, name)
 
-        desc = "My storage pool"
         storage_pool = self.client.storage_pools.get(name)
-        patch = {"description": "hello world"}
-        storage_pool.patch(patch)
-        self.assertEqual(storage_pool.description, desc)
-
+        new_desc = "new description"
+        patch_object = {
+            "description": new_desc,
+        }
+        storage_pool.patch(patch_object)
+        self.assertEqual(storage_pool.description, new_desc)
         p = self.client.storage_pools.get(name)
-        self.assertEqual(p.description, "hello world")
+        self.assertEqual(p.description, new_desc)
 
 
 class TestStorageResources(StorageTestCase):

--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -294,19 +294,19 @@ class Instance(model.Model):
     def all(cls, client, recursion=0):
         """Get all instances.
 
-        This method returns an Instance array. If recursion is unset, 
-        only the name of each instance will be set and `Instance.sync` 
-        can be used to return more information. If recursion is between 
-        1-2 this method will pre-fetch additional instance attributes for 
+        This method returns an Instance array. If recursion is unset,
+        only the name of each instance will be set and `Instance.sync`
+        can be used to return more information. If recursion is between
+        1-2 this method will pre-fetch additional instance attributes for
         all instances in the array.
         """
-        response = client.api[cls._endpoint].get(params={'recursion': recursion})
+        response = client.api[cls._endpoint].get(params={"recursion": recursion})
 
         instances = []
         for instance in response.json()["metadata"]:
             if type(instance) == dict:
                 # User specified recursion so returning all data for each instance at once
-                instance_class = cls(client, name=instance['name'])
+                instance_class = cls(client, name=instance["name"])
                 for key, data in instance.items():
                     try:
                         setattr(instance_class, key, data)

--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -300,7 +300,10 @@ class Instance(model.Model):
         1-2 this method will pre-fetch additional instance attributes for
         all instances in the array.
         """
-        response = client.api[cls._endpoint].get(params={"recursion": recursion})
+        params = {}
+        if recursion != 0:
+            params = {"recursion": recursion}
+        response = client.api[cls._endpoint].get(params=params)
 
         instances = []
         for instance in response.json()["metadata"]:

--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -862,11 +862,6 @@ class Snapshot(model.Model):
         """Publish a snapshot as an image.
 
         If wait=True, an Image is returned.
-
-        This functionality is currently broken in LXD. Please see
-        https://github.com/canonical/lxd/issues/2201 - The implementation
-        here is mostly a guess. Once that bug is fixed, we can verify
-        that this works, or file a bug to fix it appropriately.
         """
         data = {
             "public": public,


### PR DESCRIPTION
This ended up fixing a small testing regression silently introduced by another PR.

>  pylxd/models/instance: only pass recursion if not 0
>  
>  This fixes `tox -e coverage`. This was not caught when introduced by
>  PR #551 because we our CI job was still only triggering on the old
>  branch name. The CI job was fixed afterward by commit 094bab4090776468.
>     
>  The decision to omit the recursion param was taken because that's easier
>  than trying to fix the mocked HTTP responses.
