### PR TITLE
fix(generate_migration_data): doesn't keep instance type

### DIFF
--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -644,6 +644,9 @@ class Instance(model.Model):
         operation_url = self.client.api.operations[operation.id]._api_endpoint
         secrets = response.json()["metadata"]["metadata"]
         cert = self.client.host_info["environment"]["certificate"]
+        if self.config.get("volatile.vsock_id", False):
+            # Delete key/value for volatile.vsock_id as this will be different on new host. Throws an 'Unknown configuration key: volatile.vsock_id' error if we don't delete it
+            del self.config["volatile.vsock_id"]
 
         return {
             "name": self.name,
@@ -651,7 +654,8 @@ class Instance(model.Model):
             "config": self.config,
             "devices": self.devices,
             "epehemeral": self.ephemeral,
-            "default": self.profiles,
+            "profiles": self.profiles,
+            "type": self.type,
             "source": {
                 "type": "migration",
                 "operation": operation_url,


### PR DESCRIPTION
While working on a project of mine I ran across a few issues when attempting to migrate a _virtual-machine_ to another lxd host.  Both hosts are running Ubuntu 22.04 and have been tested with 5.15/stable and 5.19/stable.

1. The first issue was due to the `volatile.vsock_id` in the config. As this is volatile and unique I decided to just drop the key from the config entirely. 
2. The second issue was due to the lack of generating the "type" for the migration data. Since it isn't setting the type to its current type it was attempting to migrate my _virtual-machine_ typed instance as a _container_, thus when trying to start it back up it would not work as it had completely missed the actual `.block` zfs dataset with all the data. This was also when I realized the profiles it had set weren't being migrated correctly as well.

### Error attempting to move due to `Unknown configuration key: volatile.vsock_id`
>   File "/home/dgreeley/.../lxd.py", line 10, in move
    moved_instance = self._lxd.migrate(dest._client, live=live, wait=True)
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/models/instance.py", line 618, in migrate                                                       
    res = getattr(new_client, self._endpoint).create(
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/models/instance.py", line 340, in create                                                        
    response = client.api[cls._endpoint].post(json=config, target=target) 
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/client.py", line 230, in post                                                                                                                                            
    self._assert_response(response, allowed_status_codes=(200, 201, 202))                                                                         
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/client.py", line 159, in _assert_response                                                                                                                                
    raise exceptions.LXDAPIException(response)                                                                                                    
pylxd.exceptions.LXDAPIException: Failed creating instance record: Unknown configuration key: volatile.vsock_id

### `generate_migration_data` function does not keep the profiles or type correctly
>   File "/home/dgreeley/.../lxd.py", line 11, in move                                                    
    moved_instance.start(wait=True)                                                                                                               
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/models/instance.py", line 380, in start                                                                                                                                  
    return self._set_state("start", timeout=timeout, force=force, wait=wait)                                                                      
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/models/instance.py", line 365, in _set_state                                                                                                                             
    self.client.operations.wait_for_operation(response.json()["operation"])                                                                       
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/models/operation.py", line 57, in wait_for_operation                                            
    operation.wait()                                                     
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/models/operation.py", line 94, in wait                                                                                                                                   
    response = self._client.api.operations[self.id].wait.get()                                                                                    
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/client.py", line 207, in get
    self._assert_response(
  File "/home/dgreeley/.cache/pypoetry/virtualenvs/my-amazing-project-9Pci4AF4-py3.10/lib/python3.10/site-packages/pylxd/client.py", line 159, in _assert_response
    raise exceptions.LXDAPIException(response)
pylxd.exceptions.LXDAPIException: Failed to handle idmapped storage: No such file or directory: "/var/snap/lxd/common/lxd/storage-pools/default/containers/dgreeley-migrate-test/rootfs"