### PR TITLE
Revert "run-integration-tests-in-lxd: ignore error returned by cloud-init status

### DIFF
--- a/integration/run-integration-tests-in-lxd
+++ b/integration/run-integration-tests-in-lxd
@@ -29,8 +29,7 @@ function run_tests {
     lxc exec "$container_name" -- mkdir -p /opt/pylxd
     { cd "$DIR/.." && git archive --format=tar HEAD; } | lxc exec "$container_name" -- tar -xf - -C /opt/pylxd
 
-    # Workaround https://github.com/canonical/cloud-init/pull/4970
-    lxc exec "$container_name" -- cloud-init status --long --wait || true
+    lxc exec "$container_name" -- cloud-init status --long --wait
     lxc exec "$container_name" --cwd /opt/pylxd -- integration/run-integration-tests
     lxc delete --force "$container_name"
 }


### PR DESCRIPTION
This reverts commit 06ab061297c89222e6ba8ca114f0c264ee3cc0ec now that `cloud-init` package in `ubuntu-daily:noble` is updated to the fixed version closing https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2055219