### PR TITLE
setup.cfg: requests 2.32.0+ breaks requests-unixsocket

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 install_requires =
     cryptography >= 3.2
     python-dateutil >= 2.4.2
-    requests >= 2.20.0
+    requests >= 2.20.0, < 2.32.0
     requests-toolbelt >= 0.8.0
     requests-unixsocket >= 0.1.5
     urllib3 < 2


### PR DESCRIPTION
requests 2.32 security fix recommends a fix:
https://github.com/psf/requests/pull/6710

This was proposed (but not yet merged) to requests-unixsocket in:
https://github.com/msabramo/requests-unixsocket/pull/72

Fixes #579.