### PR TITLE
Introduce storage volume snapshots

### DIFF
--- a/doc/source/storage-pools.rst
+++ b/doc/source/storage-pools.rst
@@ -13,18 +13,22 @@ Storage Pool objects
 object that is returned from `GET /1.0/storage-pools/<name>` and then the
 associated methods that are then available at the same endpoint.
 
-There are also :py:class:`~pylxd.models.storage_pool.StorageResource` and
-:py:class:`~pylxd.models.storage_pool.StorageVolume` objects that represent the
-storage resources endpoint for a pool at `GET
-/1.0/storage-pools/<pool>/resources` and a storage volume on a pool at `GET
-/1.0/storage-pools/<pool>/volumes/<type>/<name>`.  Note that these should be
-accessed from the storage pool object.  For example:
+There are also :py:class:`~pylxd.models.storage_pool.StorageResource`,
+:py:class:`~pylxd.models.storage_pool.StorageVolume` and
+:py:class:`~pylxd.models.storage_pool.StorageVolumeSnapshot` objects that
+represent, respectively, the storage resources endpoint for a pool at
+`GET /1.0/storage-pools/<pool>/resources`, a storage volume on a pool at
+`GET /1.0/storage-pools/<pool>/volumes/<type>/<name>` and a custom volume snapshot
+at `GET /1.0/storage-pools/<pool>/volumes/<type>/<volume>/snapshots/<snapshot>`.
+Note that these should be accessed from the storage pool object.  For example:
 
 .. code:: python
 
     client = pylxd.Client()
     storage_pool = client.storage_pools.get('poolname')
+    resources = storage_pool.resources.get()
     storage_volume = storage_pool.volumes.get('custom', 'volumename')
+    snapshot = storage_volume.snapshots.get('snap0')
 
 
 .. note:: For more details of the LXD documentation concerning storage pools
@@ -137,9 +141,46 @@ following methods are available:
     changes to the LXD server.
   - `delete` - delete a storage volume object.  Note that the object is,
     therefore, stale after this action.
+  - `restore_from` - Restore the volume from a snapshot using the snapshot name.
 
 .. note:: `raw_put` and `raw_patch` are availble (but not documented) to allow
         putting and patching without syncing the object back.
+
+Storage Volume Snapshots
+------------------------
+
+Storage Volume Snapshots are represented as `StorageVolumeSnapshot` objects and
+stored in `StorageVolume` objects and represent snapshots of custom storage volumes.
+On the `pylxd` API they are accessed from a storage volume object that, in turn,
+is accessed from a storage pool object:
+
+.. code:: Python
+
+    storage_pool = client.storage_pools.get('pool1')
+    volumes = storage_pool.volumes.all()
+    custom_volume = storage_pool.volumes.get('custom', 'vol1')
+    a_snapshot = custom_volume.snapshots.get('snap0')
+
+Methods available on `<storage_volume_object>.snapshots`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following methods are accessed from the `snapshots` attribute on the `StorageVolume` object:
+
+  - `all` - Get all the snapshots from the storage volume.
+  - `get` - Get a single snapshot using its name.
+  - `create` - Take a snapshot on the current stage of the storage volume. The new snapshot's
+  name and expiration date can be set, default name is in the format "snapX".
+  - `exists` - Returns True if a storage volume snapshot with the given name exists, returns False otherwise.
+
+Methods available on the storage snapshot object
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once in possession of a `StorageVolumeSnapshot` object from the `pylxd` API via `volume.snapshots.get()`,
+the following methods are available:
+
+  - `restore` - Restore the volume from the snapshot.
+  - `delete` - Delete the snapshot. Note that the object is, therefore, stale after this action.
+  - `rename` - Renames the snapshot. The endpoints that reference this snapshot will change accordingly.
 
 .. links
 

--- a/integration/test_storage.py
+++ b/integration/test_storage.py
@@ -12,8 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import random
-import string
 import unittest
 
 import pylxd.exceptions as exceptions
@@ -26,25 +24,6 @@ class StorageTestCase(IntegrationTestCase):
 
         if not self.client.has_api_extension("storage"):
             self.skipTest("Required LXD API extension not available!")
-
-    def create_storage_pool(self):
-        # create a storage pool in the form of 'xxx1' as a dir.
-        name = "".join(random.sample(string.ascii_lowercase, 3)) + "1"
-        self.lxd.storage_pools.post(
-            json={
-                "config": {},
-                "driver": "dir",
-                "name": name,
-            }
-        )
-        return name
-
-    def delete_storage_pool(self, name):
-        # delete the named storage pool
-        try:
-            self.lxd.storage_pools[name].delete()
-        except exceptions.NotFound:
-            pass
 
 
 class TestStoragePools(StorageTestCase):

--- a/integration/test_storage.py
+++ b/integration/test_storage.py
@@ -105,36 +105,12 @@ class TestStorageResources(StorageTestCase):
 class TestStorageVolume(StorageTestCase):
     """Tests for :py:class:`pylxd.models.storage_pools.StorageVolume"""
 
-    # note create and delete are tested in every method
-
-    def create_storage_volume(self, pool):
-        # note 'pool' needs to be storage_pool object or a string
-        if isinstance(pool, str):
-            pool = self.client.storage_pools.get(pool)
-        vol_input = {
-            "config": {},
-            "type": "custom",
-            # "pool": name,
-            "name": "vol1",
-        }
-        volume = pool.volumes.create(vol_input)
-        return volume
-
-    def delete_storage_volume(self, pool, volume):
-        # pool is either string or storage_pool object
-        # volume is either a string of storage_pool object
-        if isinstance(volume, str):
-            if isinstance(pool, str):
-                pool = self.client.storage_pools.get(pool)
-            volume = pool.volumes.get("custom", volume)
-        volume.delete()
-
     def test_create_and_get_and_delete(self):
         pool_name = self.create_storage_pool()
         self.addCleanup(self.delete_storage_pool, pool_name)
-
         storage_pool = self.client.storage_pools.get(pool_name)
-        volume = self.create_storage_volume(storage_pool)
+
+        volume = self.create_storage_volume(pool_name, "vol1")
         vol_copy = storage_pool.volumes.get("custom", "vol1")
         self.assertEqual(vol_copy.name, volume.name)
         volume.delete()

--- a/integration/test_storage.py
+++ b/integration/test_storage.py
@@ -23,7 +23,7 @@ class StorageTestCase(IntegrationTestCase):
         super().setUp()
 
         if not self.client.has_api_extension("storage"):
-            self.skipTest("Required LXD API extension not available!")
+            self.skipTest("Required 'storage' LXD API extension not available!")
 
 
 class TestStoragePools(StorageTestCase):

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -157,6 +157,25 @@ class IntegrationTestCase(unittest.TestCase):
         except exceptions.NotFound:
             pass
 
+    def create_storage_pool(self):
+        # create a storage pool in the form of 'xxx1' as a dir.
+        name = "".join(random.sample(string.ascii_lowercase, 3)) + "1"
+        self.lxd.storage_pools.post(
+            json={
+                "config": {},
+                "driver": "dir",
+                "name": name,
+            }
+        )
+        return name
+
+    def delete_storage_pool(self, name):
+        # delete the named storage pool
+        try:
+            self.lxd.storage_pools[name].delete()
+        except exceptions.NotFound:
+            pass
+
     def assertCommon(self, response):
         """Assert common LXD responses.
 

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -176,6 +176,23 @@ class IntegrationTestCase(unittest.TestCase):
         except exceptions.NotFound:
             pass
 
+    def create_storage_volume(self, pool_name, volume_name):
+        pool = self.client.storage_pools.get(pool_name)
+        vol_json = {
+            "config": {},
+            "type": "custom",
+            "name": volume_name,
+        }
+        return pool.volumes.create(vol_json)
+
+    def delete_storage_volume(self, pool_name, volume_name):
+        try:
+            pool = self.client.storage_pools.get(pool_name)
+            pool.volumes.get("custom", volume_name).delete()
+            return True
+        except exceptions.NotFound:
+            return False
+
     def assertCommon(self, response):
         """Assert common LXD responses.
 

--- a/pylxd/managers.py
+++ b/pylxd/managers.py
@@ -81,6 +81,10 @@ class StorageVolumeManager(BaseManager):
     manager_for = "pylxd.models.StorageVolume"
 
 
+class StorageVolumeSnapshotManager(BaseManager):
+    manager_for = "pylxd.models.StorageVolumeSnapshot"
+
+
 class ClusterMemberManager(BaseManager):
     manager_for = "pylxd.models.ClusterMember"
 

--- a/pylxd/managers.py
+++ b/pylxd/managers.py
@@ -73,6 +73,14 @@ class StoragePoolManager(BaseManager):
     manager_for = "pylxd.models.StoragePool"
 
 
+class StorageResourcesManager(BaseManager):
+    manager_for = "pylxd.models.StorageResources"
+
+
+class StorageVolumeManager(BaseManager):
+    manager_for = "pylxd.models.StorageVolume"
+
+
 class ClusterMemberManager(BaseManager):
     manager_for = "pylxd.models.ClusterMember"
 

--- a/pylxd/models/__init__.py
+++ b/pylxd/models/__init__.py
@@ -7,7 +7,12 @@ from pylxd.models.network import Network, NetworkForward
 from pylxd.models.operation import Operation
 from pylxd.models.profile import Profile
 from pylxd.models.project import Project
-from pylxd.models.storage_pool import StoragePool, StorageResources, StorageVolume
+from pylxd.models.storage_pool import (
+    StoragePool,
+    StorageResources,
+    StorageVolume,
+    StorageVolumeSnapshot,
+)
 from pylxd.models.virtual_machine import VirtualMachine
 
 __all__ = [
@@ -27,5 +32,6 @@ __all__ = [
     "StoragePool",
     "StorageResources",
     "StorageVolume",
+    "StorageVolumeSnapshot",
     "VirtualMachine",
 ]

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -173,6 +173,21 @@ class Model(metaclass=ModelType):
         for attr in self.__attributes__.keys():
             yield attr, getattr(self, attr)
 
+    def __eq__(self, other):
+        if other.__class__ != self.__class__:
+            return False
+
+        for attr in self.__attributes__.keys():
+            if not hasattr(self, attr) and not hasattr(other, attr):
+                continue
+            try:
+                if self.__getattribute__(attr) != other.__getattribute__(attr):
+                    return False
+            except AttributeError:
+                return False
+
+        return True
+
     @property
     def dirty(self):
         return len(self.__dirty__) > 0

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -249,6 +249,20 @@ class Model(metaclass=ModelType):
                     marshalled[key] = val
         return marshalled
 
+    def post(self, json=None, wait=False):
+        """Access the POST method directly for the object.
+
+        :param wait: If wait is True, then wait here until the operation
+            completes.
+        :type wait: bool
+        :param json: Dictionary that the represents the request body used on the POST method.
+        :type wait: dict
+        :raises: :class:`pylxd.exception.LXDAPIException` on error
+        """
+        response = self.api.post(json=json)
+        if response.json()["type"] == "async" and wait:
+            self.client.operations.wait_for_operation(response.json()["operation"])
+
     def put(self, put_object, wait=False):
         """Access the PUT method directly for the object.
 

--- a/pylxd/models/storage_pool.py
+++ b/pylxd/models/storage_pool.py
@@ -591,8 +591,9 @@ class StorageVolume(model.Model):
 
         Implements: DELETE /1.0/storage-pools/<pool>/volumes/<type>/<name>
 
-        Deleting a storage volume may fail if it is being used.  See the LXD
-        documentation for further details.
+        Deleting a storage volume may fail if it is being used.
+        See https://documentation.ubuntu.com/lxd/en/latest/explanation/storage/#storage-volumes
+        for further details.
 
         :raises: :class:`pylxd.exceptions.LXDAPIExtensionNotAvailable` if the
             'storage' api extension is missing.

--- a/pylxd/models/storage_pool.py
+++ b/pylxd/models/storage_pool.py
@@ -301,6 +301,8 @@ class StorageVolume(model.Model):
     used_by = model.Attribute(readonly=True)
     location = model.Attribute(readonly=True)
 
+    snapshots = model.Manager()
+
     storage_pool = model.Parent()
 
     @property
@@ -315,6 +317,11 @@ class StorageVolume(model.Model):
         :rtype: :class:`pylxd.client._APINode`
         """
         return self.storage_pool.api.volumes[self.type][self.name]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.snapshots = managers.StorageVolumeSnapshotManager(self)
 
     @classmethod
     def all(cls, storage_pool):

--- a/pylxd/models/storage_pool.py
+++ b/pylxd/models/storage_pool.py
@@ -39,8 +39,8 @@ class StoragePool(model.Model):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.resources = StorageResourcesManager(self)
-        self.volumes = StorageVolumeManager(self)
+        self.resources = managers.StorageResourcesManager(self)
+        self.volumes = managers.StorageVolumeManager(self)
 
     @classmethod
     def get(cls, client, name):
@@ -249,10 +249,6 @@ class StoragePool(model.Model):
         super().patch(patch_object, wait)
 
 
-class StorageResourcesManager(managers.BaseManager):
-    manager_for = "pylxd.models.StorageResources"
-
-
 class StorageResources(model.Model):
     """An LXD Storage Resources model.
 
@@ -286,10 +282,6 @@ class StorageResources(model.Model):
         response = storage_pool.api.resources.get()
         resources = cls(storage_pool.client, **response.json()["metadata"])
         return resources
-
-
-class StorageVolumeManager(managers.BaseManager):
-    manager_for = "pylxd.models.StorageVolume"
 
 
 class StorageVolume(model.Model):

--- a/pylxd/models/storage_pool.py
+++ b/pylxd/models/storage_pool.py
@@ -295,6 +295,7 @@ class StorageVolume(model.Model):
 
     name = model.Attribute(readonly=True)
     type = model.Attribute(readonly=True)
+    content_type = model.Attribute(readonly=True)
     description = model.Attribute(readonly=True)
     config = model.Attribute()
     used_by = model.Attribute(readonly=True)

--- a/pylxd/models/storage_pool.py
+++ b/pylxd/models/storage_pool.py
@@ -610,3 +610,26 @@ class StorageVolume(model.Model):
         """
         # Note this method exists so that it is documented via sphinx.
         super().delete()
+
+    def restore_from(self, snapshot_name, wait=False):
+        """Restore this volume from a snapshot using its name.
+
+        Attempts to restore a volume using a snapshot identified by its name.
+
+        Implements POST /1.0/storage-pools/<pool>/volumes/custom/<volume_name>/snapshot/<name>
+
+        :param snapshot_name: the name of the snapshot to restore from
+        :type snapshot_name: str
+        :param wait: wait until the operation is completed.
+        :type wait: boolean
+        :raises: :class:`pylxd.exceptions.LXDAPIExtensionNotAvailable` if the
+            'storage' or 'storage_api_volume_snapshots' api extension is missing.
+        :raises: :class:`pylxd.exceptions.LXDAPIException` if the the operation fails.
+        :returns: the original response from the restore operation (not the
+            operation result)
+        :rtype: :class:`requests.Response`
+        """
+        response = self.api.put(json={"restore": snapshot_name})
+        if wait:
+            self.client.operations.wait_for_operation(response.json()["operation"])
+        return response


### PR DESCRIPTION
This add a few features related to custom storage volumes snapshots to pyLXD:
1. Custom volume snapshot creation
2. Custom volume edition (including renaming)
4. Restoring a custom volume from a snapshot
5. Custom volume snapshot deletion

The unit tests will be added in a later PR if necessary.
Scheduling was already supported since it is done through config key settings on the StorageVolume object.
This also does some refactoring on previously existing code and some other changes made necessary by the new features and tests.