### PR TITLE
Skip password auth tests if not supported by LXD

### DIFF
--- a/integration/run-integration-tests
+++ b/integration/run-integration-tests
@@ -18,7 +18,9 @@ fi
 # Make sure a client.{crt,key} exist by trying to add a bogus remote
 lxc remote add foo 127.0.0.1:1234 2>/dev/null || true
 
-lxc config set core.trust_password password
+if ! lxc query /1.0 | grep -q '"explicit_trust_token"$'; then
+    lxc config set core.trust_password password
+fi
 lxc config set core.https_address 127.0.0.1
 
 if ! lxc storage show default >/dev/null 2>&1; then
@@ -62,5 +64,7 @@ for cert in $(comm -13 "${OLD_TRUST_LIST}" "${NEW_TRUST_LIST}"); do
 done
 rm -f "${OLD_TRUST_LIST}" "${NEW_TRUST_LIST}"
 
-lxc config unset core.trust_password || true
+if ! lxc query /1.0 | grep -q '"explicit_trust_token"$'; then
+    lxc config unset core.trust_password || true
+fi
 lxc config unset core.https_address || true

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -21,6 +21,11 @@ class TestClient(IntegrationTestCase):
     """Tests for `Client`."""
 
     def test_authenticate(self):
+        if self.client.has_api_extension("explicit_trust_token"):
+            self.skipTest(
+                "Required LXD support for password authentication not available!"
+            )
+
         client = pylxd.Client("https://127.0.0.1:8443/")
 
         self.assertFalse(client.trusted)
@@ -30,6 +35,11 @@ class TestClient(IntegrationTestCase):
         self.assertTrue(client.trusted)
 
     def test_authenticate_with_project(self):
+        if self.client.has_api_extension("explicit_trust_token"):
+            self.skipTest(
+                "Required LXD support for password authentication not available!"
+            )
+
         try:
             client = pylxd.Client("https://127.0.0.1:8443/", project="test-project")
         except exceptions.ClientConnectionFailed as e:


### PR DESCRIPTION
We don't have tests for token auth yet but that should be done as part of #589.