### PR TITLE
README: create a venv to pip install pylxd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,16 @@ A Python library for interacting with the LXD REST API.
 
 Installation
 =============
-``pip install pylxd``
+.. code-block:: console
+
+  # Create a virtual environment
+  python3 -m venv myvenv
+  cd myvenv
+
+  # Activate the virtual environment
+  . bin/activate
+  # Install pyLXD in it
+  pip install pylxd
 
 Bug reports
 ===========

--- a/doc/source/clustering.rst
+++ b/doc/source/clustering.rst
@@ -70,4 +70,4 @@ the `LXD Cluster REST API`_ documentation.
 .. links
 
 .. _LXD Clustering: https://documentation.ubuntu.com/lxd/en/latest/clustering/
-.. _LXD REST API: https://documentation.ubuntu.com/lxd/en/latest/api/
+.. _LXD Cluster REST API: https://documentation.ubuntu.com/lxd/en/latest/api/#/cluster

--- a/doc/source/storage-pools.rst
+++ b/doc/source/storage-pools.rst
@@ -184,4 +184,4 @@ the following methods are available:
 .. links
 
 .. _LXD Storage Pools: https://documentation.ubuntu.com/lxd/en/latest/storage/
-.. _LXD REST API: https://documentation.ubuntu.com/lxd/en/latest/api/
+.. _LXD Storage Pools REST API: https://documentation.ubuntu.com/lxd/en/latest/api/#/storage

--- a/doc/source/storage-pools.rst
+++ b/doc/source/storage-pools.rst
@@ -168,8 +168,7 @@ The following methods are accessed from the `snapshots` attribute on the `Storag
 
   - `all` - Get all the snapshots from the storage volume.
   - `get` - Get a single snapshot using its name.
-  - `create` - Take a snapshot on the current stage of the storage volume. The new snapshot's
-  name and expiration date can be set, default name is in the format "snapX".
+  - `create` - Take a snapshot on the current stage of the storage volume. The new snapshot's name and expiration date can be set, default name is in the format "snapX".
   - `exists` - Returns True if a storage volume snapshot with the given name exists, returns False otherwise.
 
 Methods available on the storage snapshot object


### PR DESCRIPTION
Older Python version didn't care but BCP is to use a venv and Python 3.12 actually requires it.

Fixes #596