### PR TITLE
pylxd/models/certificate: re-add password arg for backward compat

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -478,11 +478,15 @@ class Client:
         if not self.has_api_extension(name):
             raise exceptions.LXDAPIExtensionNotAvailable(name)
 
-    def authenticate(self, secret):
+    def authenticate(self, secret, use_token_auth=True):
         if self.trusted:
             return
         cert = open(self.api.session.cert[0]).read().encode("utf-8")
-        self.certificates.create(secret, cert)
+
+        if self.has_api_extension("explicit_trust_token") and use_token_auth:
+            self.certificates.create(password="", cert_data=cert, secret=secret)
+        else:
+            self.certificates.create(password=secret, cert_data=cert)
 
         # Refresh the host info
         response = self.api.get()


### PR DESCRIPTION
Fixes https://github.com/canonical/charm-lxd/issues/168 where charm-lxd is calling certificates.create():

```python
  config: Dict[str, Union[str, bytes, List[str], bool]] = {
      "name": name,
      "password": "",
      "cert_data": cert.encode(),
  }

  client.certificates.create(**config)
```

causing:

```
  File "./src/charm.py", line 1139, in _on_https_relation_changed
    if self.lxd_trust_add(cert=cert, name=cert_name, projects=projects):
  File "./src/charm.py", line 2294, in lxd_trust_add
    client.certificates.create(**config)
TypeError: create() got an unexpected keyword argument 'password'
```

This should fix an unexpected regression introduced in commit ec1b3ee10400bf2724e7818940a6320fe2319952.