### PR TITLE
Remove `requests_unixsocket`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 .coverage
 .tox
 
+# Tox tests leftovers
+build
+
 # Translations
 *.mo
 

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -18,7 +18,7 @@ from urllib import parse
 
 import pytest
 import requests
-import requests_unixsocket
+import requests.adapters
 
 from pylxd import client, exceptions
 
@@ -631,13 +631,17 @@ class TestGetSessionForUrl(TestCase):
     def test_session_unix_socket(self):
         """http+unix URL return a requests_unixsocket session."""
         session = client.get_session_for_url("http+unix://test.com")
-        self.assertIsInstance(session, requests_unixsocket.Session)
+        self.assertIsInstance(
+            session.get_adapter("http+unix://"), requests.adapters.HTTPAdapter
+        )
 
     def test_session_http(self):
         """HTTP nodes return the default requests session."""
         session = client.get_session_for_url("http://test.com")
         self.assertIsInstance(session, requests.Session)
-        self.assertNotIsInstance(session, requests_unixsocket.Session)
+        self.assertRaises(
+            requests.exceptions.InvalidSchema, session.get_adapter, "http+unix://"
+        )
 
     def test_session_cert(self):
         """If certs are given, they're set on the Session."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,10 +20,8 @@ packages = find:
 install_requires =
     cryptography >= 3.2
     python-dateutil >= 2.4.2
-    requests >= 2.20.0, < 2.32.0
+    requests >= 2.20.0
     requests-toolbelt >= 0.8.0
-    requests-unixsocket >= 0.1.5
-    urllib3 < 2
     ws4py != 0.3.5, >= 0.3.4  # 0.3.5 is broken for websocket support
 
 [options.extras_require]


### PR DESCRIPTION
This includes implementation to connect to a Unix socket without `requests_unixsocket`. This allows us to remove this dependency along with the version restrictions for `urllib3` and `requests`;

Fixes https://github.com/canonical/pylxd/issues/583 https://github.com/canonical/pylxd/issues/600