### PR TITLE
pylxd/client: guard against cert=None

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -31,7 +31,7 @@ essentially meaning that the authentication has not yet occurred.
 
     >>> from pylxd import Client
     >>> client = Client(
-    ...     endpoint='http://10.0.0.1:8443',
+    ...     endpoint='https://10.0.0.1:8443',
     ...     cert=('lxd.crt', 'lxd.key'))
     >>> client.trusted
     False

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -24,7 +24,7 @@ certificate to the `verify` argument:
 
     >>> from pylxd import Client
     >>> client = Client(
-    ...     endpoint='http://10.0.0.1:8443',
+    ...     endpoint='https://10.0.0.1:8443',
     ...     cert=('/path/to/client.crt', '/path/to/client.key'),
     ...     verify='/path/to/server.crt')
 
@@ -38,7 +38,7 @@ for TLS verification.
 
     >>> from pylxd import Client
     >>> client = Client(
-    ...     endpoint='http://10.0.0.1:8443',
+    ...     endpoint='https://10.0.0.1:8443',
     ...     cert=('/path/to/client.crt', '/path/to/client.key'),
     ...     verify=False)
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -570,7 +570,15 @@ class Client:
     def authenticate(self, secret, use_token_auth=True):
         if self.trusted:
             return
-        cert = open(self.api.session.cert[0]).read().encode("utf-8")
+
+        if not isinstance(self.api.session.cert, tuple):
+            raise exceptions.ClientConnectionFailed("No client certificate specified")
+
+        try:
+            with open(self.api.session.cert[0]) as f:
+                cert = f.read().encode("utf-8")
+        except FileNotFoundError:
+            raise exceptions.ClientConnectionFailed("Client certificate not found")
 
         # Quirk to handle 5.21 that supports explicit trust tokens as well as
         # password auth. We need to ascertain if the provided secret is indeed a


### PR DESCRIPTION
```
>>> import pylxd
>>> c = pylxd.Client(endpoint="https://127.0.0.1:8443/", cert=None,  verify=False)
/opt/pylxd/.tox/integration/lib/python3.12/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host '127.0.0.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
>>> c.authenticate("password")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/pylxd/.tox/integration/lib/python3.12/site-packages/pylxd/client.py", line 573, in authenticate
    cert = open(self.api.session.cert[0]).read().encode("utf-8")
                ~~~~~~~~~~~~~~~~~~~~~^^^
TypeError: 'NoneType' object is not subscriptable
```