### PR TITLE
Drop `wait` argument from image create

### DIFF
--- a/doc/source/images.rst
+++ b/doc/source/images.rst
@@ -19,7 +19,7 @@ methods:
 And create through the following methods, there's also a copy method on an
 image:
 
-  - `create(data, public=False, wait=True)` - Create a new image. The first
+  - `create(data, public=False)` - Create a new image. The first
     argument is the binary data of the image itself. If the image is public,
     set `public` to `True`.
   - `create_from_simplestreams(server, alias, public=False, auto_update=False, wait=False)` -

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -49,7 +49,7 @@ class TestImages(IntegrationTestCase):
 
         with open(path, "rb") as f:
             data = f.read()
-            image = self.client.images.create(data, wait=True)
+            image = self.client.images.create(data)
 
         self.assertEqual(fingerprint, image.fingerprint)
 

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -113,7 +113,7 @@ class Image(model.Model):
 
         if wait is False:  # pragma: no cover
             warnings.warn(
-                "Image.create wait parameter ignored and will be removed in " "2.3",
+                "Image.create wait parameter ignored and will be removed",
                 DeprecationWarning,
             )
 

--- a/pylxd/models/tests/test_image.py
+++ b/pylxd/models/tests/test_image.py
@@ -109,7 +109,7 @@ class TestImage(testing.PyLXDTestCase):
     def test_create(self):
         """An image is created."""
         fingerprint = hashlib.sha256(b"").hexdigest()
-        a_image = models.Image.create(self.client, b"", public=True, wait=True)
+        a_image = models.Image.create(self.client, b"", public=True)
 
         self.assertIsInstance(a_image, models.Image)
         self.assertEqual(fingerprint, a_image.fingerprint)
@@ -117,9 +117,7 @@ class TestImage(testing.PyLXDTestCase):
     def test_create_with_metadata(self):
         """An image with metadata is created."""
         fingerprint = hashlib.sha256(b"").hexdigest()
-        a_image = models.Image.create(
-            self.client, b"", metadata=b"", public=True, wait=True
-        )
+        a_image = models.Image.create(self.client, b"", metadata=b"", public=True)
 
         self.assertIsInstance(a_image, models.Image)
         self.assertEqual(fingerprint, a_image.fingerprint)
@@ -128,7 +126,7 @@ class TestImage(testing.PyLXDTestCase):
         """An image with metadata is created."""
         fingerprint = hashlib.sha256(b"").hexdigest()
         a_image = models.Image.create(
-            self.client, StringIO(""), metadata=StringIO(""), public=True, wait=True
+            self.client, StringIO(""), metadata=StringIO(""), public=True
         )
 
         self.assertIsInstance(a_image, models.Image)


### PR DESCRIPTION
This removes a useless parameter that was supposed to be removed on 2.3 release.