### PR TITLE
Introduce missing fields on `StorageVolume` and `Image`

### DIFF
--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -49,6 +49,9 @@ class Image(model.Model):
     size = model.Attribute(readonly=True)
     uploaded_at = model.Attribute(readonly=True)
     update_source = model.Attribute(readonly=True)
+    type = model.Attribute(readonly=True)
+    project = model.Attribute(readonly=True)
+    profiles = model.Attribute(readonly=True)
 
     @property
     def api(self):

--- a/pylxd/models/storage_pool.py
+++ b/pylxd/models/storage_pool.py
@@ -300,6 +300,10 @@ class StorageVolume(model.Model):
     config = model.Attribute()
     used_by = model.Attribute(readonly=True)
     location = model.Attribute(readonly=True)
+    # Date strings follow the ISO 8601 pattern
+    created_at = model.Attribute(readonly=True)
+    pool = model.Attribute(readonly=True)
+    project = model.Attribute(readonly=True)
 
     snapshots = model.Manager()
 


### PR DESCRIPTION
The integration tests are showing many warnings similar to `UserWarning: Attempted to set unknown attribute "type" on instance of "Image"`, due to PyLXD not recognizing some newish fields from a few API responses. This introduces such fields to PyLXD.