### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,12 +73,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.10", "3.12"]
         track: ["latest/edge", "5.21/edge", "5.0/edge"]
         os: ["24.04"]
         include:
           # 4.0/* isn't supported on 24.04
-          - python-version: "3.8"
+          - python-version: "3.10"
             track: "4.0/edge"
             os: "22.04"
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -64,11 +64,9 @@ class EventType(Enum):
     Lifecycle = "lifecycle"
 
 
-class _UnixSocketHTTPConnection(urllib3.connection.HTTPConnection, object):
+class _UnixSocketHTTPConnection(urllib3.connection.HTTPConnection):
     def __init__(self, unix_socket_url):
-        super(_UnixSocketHTTPConnection, self).__init__(
-            "localhost", timeout=SOCKET_CONNECTION_TIMEOUT
-        )
+        super().__init__("localhost", timeout=SOCKET_CONNECTION_TIMEOUT)
         self.unix_socket_url = unix_socket_url
         self.timeout = SOCKET_CONNECTION_TIMEOUT
         self.sock = None
@@ -87,7 +85,7 @@ class _UnixSocketHTTPConnection(urllib3.connection.HTTPConnection, object):
 
 class _UnixSocketHTTPConnectionPool(urllib3.HTTPConnectionPool):
     def __init__(self, socket_path):
-        super(_UnixSocketHTTPConnectionPool, self).__init__("localhost")
+        super().__init__("localhost")
         self.socket_path = socket_path
 
     def _new_conn(self):
@@ -96,7 +94,7 @@ class _UnixSocketHTTPConnectionPool(urllib3.HTTPConnectionPool):
 
 class _UnixAdapter(requests.adapters.HTTPAdapter):
     def __init__(self, pool_connections=25, *args, **kwargs):
-        super(_UnixAdapter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.pools = urllib3._collections.RecentlyUsedContainer(
             pool_connections, dispose_func=lambda p: p.close()
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifier =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.10
 packages = find:
 install_requires =
     cryptography >= 3.2


### PR DESCRIPTION
The rationals for dropping support for Python 3.8 are:

* this used to be the default Python version in Ubuntu 20.04 which is now out of standard support (EOL)
* Ubuntu releases (including 20.04 now in ESM) all use the ancient pylxd version 2.2.10 (lacking VM support) so they won't be affected
* Supporting Python 3.8 is holding back development (https://github.com/canonical/pylxd/issues/615#issuecomment-2663275517)

If accepted, this will unblock #626 