### PR TITLE
Feature/preserve file mode

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -42,5 +42,6 @@ These are the contributors to pylxd according to the Github repository.
  fliiiix          Felix
  simondeziel      Simon Déziel (Canonical)
  sparkiegeek      Adam Collard (Canonical)
+ mate-amargo      Juan Alberto Regalado Galvan
  ===============  ==================================
 


### PR DESCRIPTION
# What does this do?

Adds support for preserving file permissions when putting files in containers.

# How it does that?

I modified the `mode` argument to `put` and `recursive_put` to also allow a boolean.
If it's `True`, it preserves the file permissions from the source.
If it's `False`, it defaults to the same behavior as when `mode=None`.

# Why? (Motivation for the change)

While using pylxd to copy resources to a container, I needed to copy a bash
script and keep it executable inside the container. This was easy just
providing the `mode` argument to `container.files.put`. However, later I wanted
to recursively put all files from a resources directory, but by using
`recursive_put` I lost the ability to preserve the file mode without rewriting
the recursive put myself.
