### PR TITLE
Make websockets use client's certificate data in `execute` method

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -491,6 +491,10 @@ class Client:
         self.api = _APINode(
             f"{endpoint}/{version}", session, timeout=timeout, project=project
         )
+        use_ssl = self.api.scheme == "https" and self.cert
+        self.ssl_options = (
+            {"certfile": self.cert[0], "keyfile": self.cert[1]} if use_ssl else None
+        )
 
         # Verify the connection is valid.
         try:
@@ -634,11 +638,7 @@ class Client:
         if websocket_client is None:
             websocket_client = _WebsocketClient
 
-        use_ssl = self.api.scheme == "https" and self.cert
-        ssl_options = (
-            {"certfile": self.cert[0], "keyfile": self.cert[1]} if use_ssl else None
-        )
-        client = websocket_client(self.websocket_url, ssl_options=ssl_options)
+        client = websocket_client(self.websocket_url, ssl_options=self.ssl_options)
         parsed = parse.urlparse(self.api.events._api_endpoint)
 
         resource = parsed.path

--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -482,6 +482,7 @@ class Instance(model.Model):
                 self.client.websocket_url,
                 payload=stdin_payload,
                 encoding=stdin_encoding,
+                ssl_options=self.client.ssl_options,
             )
             stdin.resource = f"{parsed.path}?secret={fds['0']}"
             stdin.connect()
@@ -491,6 +492,7 @@ class Instance(model.Model):
                 encoding=encoding,
                 decode=decode,
                 handler=stdout_handler,
+                ssl_options=self.client.ssl_options,
             )
             stdout.resource = f"{parsed.path}?secret={fds['1']}"
             stdout.connect()
@@ -500,6 +502,7 @@ class Instance(model.Model):
                 encoding=encoding,
                 decode=decode,
                 handler=stderr_handler,
+                ssl_options=self.client.ssl_options,
             )
             stderr.resource = f"{parsed.path}?secret={fds['2']}"
             stderr.connect()


### PR DESCRIPTION
Fixes: https://github.com/canonical/pylxd/issues/666